### PR TITLE
implement an http1+json endpoint to enable use of ratelimit service from

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,14 @@ services:
       - .:/go/src/github.com/envoyproxy/ratelimit
       - binary:/usr/local/bin/
 
+  ratelimit-client-build:
+    image: golang:1.14-alpine
+    working_dir: /go/src/github.com/envoyproxy/ratelimit
+    command: go build -o /usr/local/bin/ratelimit_client ./src/client_cmd/main.go
+    volumes:
+      - .:/go/src/github.com/envoyproxy/ratelimit
+      - binary:/usr/local/bin/
+
   ratelimit:
     image: alpine:3.6
     command: /usr/local/bin/ratelimit
@@ -29,6 +37,7 @@ services:
     depends_on:
       - redis
       - ratelimit-build
+      - ratelimit-client-build
     networks:
       - ratelimit-network
     volumes:
@@ -36,7 +45,7 @@ services:
       - ./examples:/data
     environment:
       - USE_STATSD=false
-      - LOG_LEVEL=debug
+#      - LOG_LEVEL=debug
       - REDIS_SOCKET_TYPE=tcp
       - REDIS_URL=redis:6379
       - RUNTIME_ROOT=/data

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v2"
 	"net/http"
 
 	"github.com/lyft/goruntime/loader"
@@ -25,6 +26,7 @@ type Server interface {
 	 * Add an HTTP endpoint to the local debug port.
 	 */
 	AddDebugHttpEndpoint(path string, help string, handler http.HandlerFunc)
+	AddJsonHandler(pb.RateLimitServiceServer)
 
 	/**
 	 * Returns the embedded gRPC server to be used for registering gRPC endpoints.

--- a/src/server/server_impl.go
+++ b/src/server/server_impl.go
@@ -54,6 +54,10 @@ func (server *server) AddDebugHttpEndpoint(path string, help string, handler htt
 	server.debugListener.endpoints[path] = help
 }
 
+// add an http/1 handler at the /json endpoint which allows this ratelimit service to work with
+// clients that cannot use the gRPC interface (e.g. lua)
+// example usage from cURL with domain "dummy" and descriptor "perday":
+// echo '{"domain": "dummy", "descriptors": [{"entries": [{"key": "perday"}]}]}' | curl -vvvXPOST --data @/dev/stdin localhost:8080/json
 func (server *server) AddJsonHandler(svc pb.RateLimitServiceServer) {
 	handler := func(writer http.ResponseWriter, request *http.Request) {
 		var req pb.RateLimitRequest

--- a/src/service_cmd/runner/runner.go
+++ b/src/service_cmd/runner/runner.go
@@ -75,6 +75,8 @@ func (runner *Runner) Run() {
 			io.WriteString(writer, service.GetCurrentConfig().Dump())
 		})
 
+	srv.AddJsonHandler(service)
+
 	// Ratelimit is compatible with two proto definitions
 	// 1. data-plane-api rls.proto: https://github.com/envoyproxy/data-plane-api/blob/master/envoy/service/ratelimit/v2/rls.proto
 	pb.RegisterRateLimitServiceServer(srv.GrpcServer(), service)

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -3,8 +3,10 @@
 package integration_test
 
 import (
+	"bytes"
 	"fmt"
 	"math/rand"
+	"net/http"
 	"os"
 	"strconv"
 	"testing"
@@ -344,6 +346,9 @@ func TestBasicConfigLegacy(t *testing.T) {
 
 	assert := assert.New(t)
 	conn, err := grpc.Dial("localhost:8083", grpc.WithInsecure())
+	//http_resp, err := http.Post("http://localhost:8082/json", "application/json", bytes.NewBuffer(json_body))
+	//defer http_resp.Body.Close()
+	//http_resp = http_resp
 	assert.NoError(err)
 	defer conn.Close()
 	c := pb_legacy.NewRateLimitServiceClient(conn)
@@ -357,6 +362,25 @@ func TestBasicConfigLegacy(t *testing.T) {
 			Statuses:    []*pb_legacy.RateLimitResponse_DescriptorStatus{{Code: pb_legacy.RateLimitResponse_OK, CurrentLimit: nil, LimitRemaining: 0}}},
 		response)
 	assert.NoError(err)
+
+	json_body := []byte(`{
+		"domain": "basic",
+		"descriptors": [
+			{
+				"entries": [
+					{
+						"key": "one_per_minute"
+					}
+				]
+			}
+		]
+	}`)
+	http_resp, _ := http.Post("http://localhost:8082/json", "application/json", bytes.NewBuffer(json_body))
+	assert.Equal(http_resp.StatusCode, 200)
+	http_resp.Body.Close()
+
+	http_resp, _ = http.Post("http://localhost:8082/json", "application/json", bytes.NewBuffer(json_body))
+	assert.Equal(http_resp.StatusCode, 429)
 
 	response, err = c.ShouldRateLimit(
 		context.Background(),

--- a/test/integration/runtime/current/ratelimit/config/basic.yaml
+++ b/test/integration/runtime/current/ratelimit/config/basic.yaml
@@ -9,3 +9,8 @@ descriptors:
     rate_limit:
       unit: second
       requests_per_unit: 50
+
+  - key: one_per_minute
+    rate_limit:
+      unit: minute
+      requests_per_unit: 1


### PR DESCRIPTION
istio < 1.5
Using the ratelimit service from istio requires EnvoyFilters from istio >= 1.5.  We're running istio 1.1, so we'll need to implement rate limiting from lua.  Lua doesn't support gRPC. So we need an http1+json endpoint